### PR TITLE
Fix bug causing EventEmitter memory leak detected warning.

### DIFF
--- a/lib/node-impala.js
+++ b/lib/node-impala.js
@@ -26,6 +26,12 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+var _onErrorDeferred = function _onErrorDeferred(deferred) {
+  return function (err) {
+    deferred.reject(err);
+  };
+};
+
 /**
  * The class contains essential functions for executing queries
  * via Beeswax Service.
@@ -48,7 +54,7 @@ var ImpalaClient = function () {
      * @returns {function|promise}
      */
     value: function connect() {
-      var props = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+      var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       var callback = arguments[1];
 
       this.host = props.host || '127.0.0.1';
@@ -68,9 +74,7 @@ var ImpalaClient = function () {
       var connection = _thrift2.default.createConnection(this.host, this.port, this.options);
       var client = _thrift2.default.createClient(_ImpalaService2.default, connection);
 
-      connection.on('error', function (err) {
-        deferred.reject(err);
-      });
+      connection.on('error', _onErrorDeferred(deferred));
 
       connection.on('connect', function () {
         deferred.resolve('Connection is established.');
@@ -193,30 +197,40 @@ var ImpalaClient = function () {
       if (!client || !connection) {
         deferred.reject(new Error('Connection was not created.'));
       } else {
-        connection.on('error', function (err) {
-          return deferred.reject(err);
-        });
+        (function () {
+          // increase the maximum number of listeners by 1
+          // while this promise is in progress
+          connection.setMaxListeners(connection.getMaxListeners() + 1);
 
-        client.query(query).then(function (handle) {
-          return [handle, client.get_state(handle)];
-        }).spread(function (handle, state) {
-          return [handle, state, client.fetch(handle)];
-        }).spread(function (handle, state, result) {
-          return [handle, state, result, client.get_results_metadata(handle)];
-        }).spread(function (handle, state, result, metaData) {
-          var schemas = metaData.schema.fieldSchemas;
-          var data = result.data;
-          var processedData = _.processData(data, schemas, resultType);
+          var onErrorCallback = _onErrorDeferred(deferred);
+          connection.on('error', onErrorCallback);
 
-          deferred.resolve(processedData);
+          client.query(query).then(function (handle) {
+            return [handle, client.get_state(handle)];
+          }).spread(function (handle, state) {
+            return [handle, state, client.fetch(handle)];
+          }).spread(function (handle, state, result) {
+            return [handle, state, result, client.get_results_metadata(handle)];
+          }).spread(function (handle, state, result, metaData) {
+            var schemas = metaData.schema.fieldSchemas;
+            var data = result.data;
+            var processedData = _.processData(data, schemas, resultType);
 
-          return handle;
-        }).then(function (handle) {
-          client.clean(handle.id);
-          client.close(handle);
-        }).catch(function (err) {
-          return deferred.reject(err);
-        });
+            deferred.resolve(processedData);
+
+            return handle;
+          }).then(function (handle) {
+            client.clean(handle.id);
+
+            // this promise is done, so we lower the maximum number of listeners
+            connection.setMaxListeners(connection.getMaxListeners() - 1);
+            connection.removeListener('error', onErrorCallback);
+
+            client.close(handle);
+          }).catch(function (err) {
+            return deferred.reject(err);
+          });
+        })();
       }
 
       deferred.promise.nodeify(callback);


### PR DESCRIPTION
The following warning would be caused after issuing 10 queries:
(node) warning: possible EventEmitter memory leak detected. 11 a listeners added. Use emitter.setMaxListeners() to increase limit.
The fix was to remove the listener for the 'error' event once the data has been successfully received.